### PR TITLE
Point，Size，Bounds判断的修改

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,11 +1,14 @@
 import isEqual from 'lodash.isequal';
 import BMapUtil from './map';
 
+const numberRe = /^[0-9]+.?[0-9]*/;
+const latLngRe = /^-?[0-9]+.?[0-9]*/;;
+
 /**
  * 是否为Point
  * @param {*} point
  */
-const isPoint = point => typeof point.lng === 'number' && typeof point.lat === 'number';
+const isPoint = point => latLngRe.test(point.lng) && typeof latLngRe.test(point.lat);
 
 /**
  * 是否为BMap.Point
@@ -17,7 +20,7 @@ const isBPoint = point => isPoint(point) && point.equals;
  * 是否为Size
  * @param {*} point
  */
-const isSize = size => typeof size.width === 'number' && typeof size.height === 'number';
+const isSize = size => numberRe.test(size.width) && typeof numberRe.test(size.height);
 
 /**
  * 是否为BMap.Size
@@ -29,7 +32,7 @@ const isBSize = size => isSize(size) && size.equals;
  * 是否为矩形范围
  * @param {*} bounds
  */
-const isBounds = bounds => isPoint(bounds.sw) && isPoint(bounds.ne);
+const isBounds = bounds => numberRe.test(bounds.sw) && numberRe.test(bounds.ne);
 
 /**
  * 是否为BMap.Bounds

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,8 +1,6 @@
 import isEqual from 'lodash.isequal';
 import BMapUtil from './map';
 
-const numberRe = /^[0-9]+.?[0-9]*/;
-
 /**
  * 是否为Point
  * @param {*} point

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -7,7 +7,7 @@ const numberRe = /^[0-9]+.?[0-9]*/;
  * 是否为Point
  * @param {*} point
  */
-const isPoint = point => numberRe.test(point.lng) && typeof numberRe.test(point.lat);
+const isPoint = point => typeof point.lng === 'number' && typeof point.lat === 'number';
 
 /**
  * 是否为BMap.Point
@@ -19,7 +19,7 @@ const isBPoint = point => isPoint(point) && point.equals;
  * 是否为Size
  * @param {*} point
  */
-const isSize = size => numberRe.test(size.width) && typeof numberRe.test(size.height);
+const isSize = size => typeof size.width === 'number' && typeof size.height === 'number';
 
 /**
  * 是否为BMap.Size
@@ -31,7 +31,7 @@ const isBSize = size => isSize(size) && size.equals;
  * 是否为矩形范围
  * @param {*} bounds
  */
-const isBounds = bounds => numberRe.test(bounds.sw) && numberRe.test(bounds.ne);
+const isBounds = bounds => isPoint(bounds.sw) && isPoint(bounds.ne);
 
 /**
  * 是否为BMap.Bounds


### PR DESCRIPTION
Point接收的参数为两个Number类型，只需要判断是否为number类型就可以了，lng和lat在国外有为负数的情况，当前的判断有问题，如果出现负数会报错，而且只判断了lng，typeof返回的是字符串，lat永远都是true，下面的Size是同样的问题，只需要接收number类型的参数就足够了。
Bounds的sw和ne百度地图的文档是Point类型，现在是把他们当初number类型来判断。